### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-
 # Twelve Data MCP Server
 
-## Overview
-
 The Twelve Data MCP Server provides a seamless integration with the Twelve Data API to access financial market data. It enables retrieval of historical time series, real-time quotes, and instrument metadata for stocks, forex pairs, and cryptocurrencies.
+
+<a href="https://glama.ai/mcp/servers/@twelvedata/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@twelvedata/mcp/badge" alt="Twelve Data Server MCP server" />
+</a>
 
 > Note: This server is currently in early-stage development; features and tools may evolve alongside updates to the Twelve Data API.
 
@@ -93,7 +94,6 @@ Add the following snippet to your `claude_desktop_config.json`:
   }
 }
 ```
-
 
 or this one, to use our remote http server
 


### PR DESCRIPTION
This PR adds a badge for the [Twelve Data MCP Server](https://glama.ai/mcp/servers/@twelvedata/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@twelvedata/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@twelvedata/mcp/badge" alt="Twelve Data Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.